### PR TITLE
Update peak manager

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,4 +43,4 @@ TESLA_TOKEN_FILE = "/root/tesla.token"
 TESLA_PRODUCTS_URL = "https://owner-api.teslamotors.com/api/1/products"
 TESLA_ENERGY_SITE_URL = f"https://owner-api.teslamotors.com/api/1/energy_sites/{TESLA_ENERGY_SITE_ID}/site_info"
 TESLA_OPERATIONS_URL = f"https://owner-api.teslamotors.com/api/1/energy_sites/{TESLA_ENERGY_SITE_ID}/operation"
-
+TESLA_RESERVE_URL = f"https://owner-api.teslamotors.com/api/1/energy_sites/{TESLA_ENERGY_SITE_ID}/backup"


### PR DESCRIPTION
Changes to Tesla api broke functionality of switching between backup/self-powered mode.

no errors/exceptions are thrown by change, but the backup "mode" appears to set the battery reserve % to 100%, and this is retained when set back to "self-powered". Updating methodology to instead simply leave the mode the same (self powered or autonomous) and instead toggle the battery_reserve_percent between 0 & 100.

Also corrected some typod variables in the exception block for guser & gpwrd (imported from credentials)